### PR TITLE
Add support for gnome 42

### DIFF
--- a/sound-percentage@maestroschan.fr/metadata.json
+++ b/sound-percentage@maestroschan.fr/metadata.json
@@ -3,6 +3,7 @@
 	"description": "Display the current sound percentage in the system tray",
 	"name": "Sound percentage",
 	"shell-version": [
+		"42",
 		"3.36"
 	],
 	"url": "https://github.com/maoschanz/sound-percentage-gs-extension",


### PR DESCRIPTION
I have tested this extension on gnome 42 by adding that flag to the metadata.json file. The extension works as expected